### PR TITLE
Sandbox

### DIFF
--- a/Catalog.lua
+++ b/Catalog.lua
@@ -695,8 +695,9 @@ end
 
 
 function AddPermaLink()
-    -- populate ItemInfo5 (resource URL) field with a permalink to primo record.
+    -- populate RecordURL field with a permalink to primo record.
     -- We can use the address of the primo page currently displayed in the
     -- addon when the import button is clicked. 
-    SetFieldValue('Transaction', 'ItemInfo5', catalogSearchForm.Browser.WebBrowser.Address);
+    log:Debug("adding Permalink");
+    SetFieldValue('Transaction.CustomFields', 'RecordURL', catalogSearchForm.Browser.WebBrowser.Address);
 end

--- a/Catalog.lua
+++ b/Catalog.lua
@@ -645,40 +645,30 @@ function GetBibliographicInformation()
             -- Loops through each Bibliographic mapping
             for _, target in ipairs(DataMapping.ImportFields.Bibliographic[product]) do
                 if (target and target.Field and target.Field ~= "") then
-                    log:DebugFormat("Value: {0}", target.Value);
+                    log:DebugFormat("xPath =: {0}", target.Value);
                     log:DebugFormat("Target: {0}", target.Field);
-                    local marcSets = Utility.StringSplit(',', target.Value );
-                    log:DebugFormat("marcSets.Count = {0}", #marcSets);
+                    local datafieldNode = recordNode:SelectNodes(target.Value);
+                    log:DebugFormat("DataField Node Match Count: {0}", datafieldNode.Count);
 
-                    -- Loops through the MARC sets array
-                    for _, xPath in ipairs(marcSets) do
-                        log:DebugFormat("xPath = {0}", xPath);
-                        local datafieldNode = recordNode:SelectNodes(xPath);
-                        log:DebugFormat("DataField Node Match Count: {0}", datafieldNode.Count);
+                    if (datafieldNode.Count > 0) then
+                        local fieldValue = "";
 
-                        if (datafieldNode.Count > 0) then
-                            local fieldValue = "";
-
-                            -- Loops through each data field node retured from xPath and concatenates them (generally only 1)
-                            for datafieldNodeIndex = 0, (datafieldNode.Count - 1) do
-                                log:DebugFormat("datafieldnode value is: {0}", datafieldNode:Item(datafieldNodeIndex).InnerText);
-                                fieldValue = fieldValue .. " " .. datafieldNode:Item(datafieldNodeIndex).InnerText;
-                            end
-
-                            log:DebugFormat("target.Field: {0}", target.Field);
-                            log:DebugFormat("target.MaxSize: {0}", target.MaxSize);
-
-                            if(settings.RemoveTrailingSpecialCharacters) then
-                                fieldValue = Utility.RemoveTrailingSpecialCharacters(fieldValue);
-                            else
-                                fieldValue = Utility.Trim(fieldValue);
-                            end
-
-                            AddBibliographicInformation(bibliographicInformation, target.Table, target.Field, fieldValue, target.MaxSize);
-
-                            -- Need to break from MARC Set loop so the first record isn't overwritten
-                            break;
+                        -- Loops through each data field node retured from xPath and concatenates them (generally only 1)
+                        for datafieldNodeIndex = 0, (datafieldNode.Count - 1) do
+                            log:DebugFormat("datafieldnode value is: {0}", datafieldNode:Item(datafieldNodeIndex).InnerText);
+                            fieldValue = fieldValue .. " " .. datafieldNode:Item(datafieldNodeIndex).InnerText;
                         end
+
+                        log:DebugFormat("target.Field: {0}", target.Field);
+                        log:DebugFormat("target.MaxSize: {0}", target.MaxSize);
+
+                        if(settings.RemoveTrailingSpecialCharacters) then
+                            fieldValue = Utility.RemoveTrailingSpecialCharacters(fieldValue);
+                        else
+                            fieldValue = Utility.Trim(fieldValue);
+                        end
+
+                        AddBibliographicInformation(bibliographicInformation, target.Table, target.Field, fieldValue, target.MaxSize);
                     end
                 end
             end

--- a/DataMapping.lua
+++ b/DataMapping.lua
@@ -78,7 +78,20 @@ DataMapping.ImportFields.Bibliographic["Aeon"] = {
         Table = "Transaction.CustomFields",
         Field ="SeriesNumber", MaxSize = 255,
         Value = "//datafield[@tag='830']"
+    },
+-- OCLC Number
+    {
+        Table = "Transaction.CustomFields",
+        Field = "OCLCNum", MaxSize = 255,
+        Value = "//datafield[@tag='035']"
+    },
+-- DSpace URL
+    {
+        Table = "Transaction.CustomFields",
+        Field = "DspaceURL", MaxSize = 255,
+        Value = "//datafield[@tag='856'][subfield[text()[contains(.,'DSpace@MIT')]]]/subfield[@code='u']"
     }
+
 };
 
 

--- a/DataMapping.lua
+++ b/DataMapping.lua
@@ -71,12 +71,12 @@ DataMapping.ImportFields.Bibliographic["Aeon"] = {
 -- Volume/box - shirea 5/2021
         Table = "Transaction",
         Field ="ItemVolume", MaxSize = 255,
-        Value = "//datafield[@tag='598']/subfield[@code='p']|//datafield[@tag='598']/subfield[@code='b']"
+        Value = "//datafield[@tag='988']/subfield[@code='p']|//datafield[@tag='988']/subfield[@code='b']"
     },
     {
 -- Series - shirea 5/2021
-        Table = "Transaction",
-        Field ="ItemInfo2", MaxSize = 255, 
+        Table = "Transaction.CustomFields",
+        Field ="SeriesNumber", MaxSize = 255,
         Value = "//datafield[@tag='830']"
     }
 };
@@ -104,8 +104,8 @@ DataMapping.ImportFields.Item["Aeon"] = {
         Value = "Location"
     },
     {
-        Table = "Transaction",
-        Field = "ItemInfo1", MaxSize = 255,
+        Table = "Transaction.CustomFields",
+        Field = "Issue", MaxSize = 255,
         Value = "Description"
     }
 };

--- a/DataMapping.lua
+++ b/DataMapping.lua
@@ -49,7 +49,7 @@ DataMapping.ImportFields.Bibliographic["Aeon"] = {
     {
         Table = "Transaction",
         Field = "ItemAuthor", MaxSize = 255,
-        Value = "//datafield[@tag='100']/subfield[@code='a']|//datafield[@tag='100']/subfield[@code='b'],//datafield[@tag='110']/subfield[@code='a']|//datafield[@tag='110']/subfield[@code='b'],//datafield[@tag='111']/subfield[@code='a']|//datafield[@tag='111']/subfield[@code='b']"
+        Value = "//datafield[@tag='100' or @tag='110' or @tag='111']/subfield[@code='a' or @code='b']"
     },
     {
         Table = "Transaction",

--- a/DataMapping.lua
+++ b/DataMapping.lua
@@ -83,7 +83,7 @@ DataMapping.ImportFields.Bibliographic["Aeon"] = {
     {
         Table = "Transaction.CustomFields",
         Field = "OCLCNum", MaxSize = 255,
-        Value = "//datafield[@tag='035']"
+        Value = "//datafield[@tag='035'][subfield[text()[contains(.,'(OCoLC)')]]][1]"
     },
 -- DSpace URL
     {

--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ The field that the addon reads from to perform the search.
 ### Bibliographic Import
 The information within this data mapping is used to perform the bibliographic api call. The `Field` is the product field that the data will be imported into, `MaxSize` is the maximum character size the data going into the product field can be, and `Value` is the xPath query to the information.
 
->**Note:** One may specify multiple xPath queries for a single field by separating them with a comma. The addon will try each xPath query and returns the first successful one.
->
->*Example:* An author can be inside of `100$a and 100$b` or `110$a and 110$b`. To accomplish this, provide an xPath query for the 100 datafields and an xPath query for the 110 datafields separated by a comma.
->```
->//datafield[@tag='100']/subfield[@code='a']|//datafield[@tag='100']/subfield[@code='b'],
->//datafield[@tag='110']/subfield[@code='a']|//datafield[@tag='110']/subfield[@code='b']
->```
+>**Note:** Previously, the addon allowed one to specify multiple xPath queries for a single field by separating them with a comma. This prevented the use of Xpath expressions which contained commas, so the functionality was removed. Instead, one should use Xpath operators to specify multiple Xpath queries for a single field.
+
+for example, to import subfields 'a' and 'b' from either the MARC 100, 110, or 111 use:
+
+`//datafield[@tag='100' or @tag='110' or @tag='111']/subfield[@code='a' or @code='b']`.
+
+If you expect more than one of the MARC fields in the Xpath expression could exist simultaneously, you can use '[1]' notation to select the first matching node.
+
+`//datafield[@tag='100' or @tag='110' or @tag='111'][1]/subfield[@code='a' or @code='b']`
 
 ### Item Import
 The information within this data mapping is used import the correct information from the items grid. The `Field` is the product field that the data will be imported into, `MaxSize` is the maximum character size the data going into the product field can be, and `Value` is the FieldName of the column within the item grid.

--- a/RegEx.lua
+++ b/RegEx.lua
@@ -1,0 +1,11 @@
+RegEx = {};
+
+local function Match(pattern, text)
+    local types = {};
+    types["Regex"] = luanet.import_type("System.Text.RegularExpressions.Regex");
+    
+    local regex = types["Regex"](pattern);
+    return regex:Match(text);
+end
+
+RegEx.Match = Match;


### PR DESCRIPTION
### Why these changes are being introduced
regular expression handling script was missing

adds new custom field mappings created during upgrade to Aeon 5.1

improves Xpath expression handling for selecting multiple MARC fields and subfields

### How this addresses that need

adds regular expressions handling script

Changed field mapping names in DataMapping.lua

Previously, importing data from multiple MARC fields to a single request form
field required including multiple xpath expressions separated by commas in DataMapping.lua.
This prevented xpath expressions that required commas from being used at all. Since it is already
possible to create native xpath expressions that select from multiple fields, the splitting at commas 
functionality was removed, and handling for xpath expressions selecting from multiple MARC fields and subfields
was added. 

### Side effects of this change

none

### Relevant ticket(s)


https://mitlibraries.atlassian.net/browse/ES-869